### PR TITLE
Ajout fermeture Esc et accessibilité des popups

### DIFF
--- a/assets/popups.js
+++ b/assets/popups.js
@@ -34,4 +34,17 @@
             $('#wdp-popup-exit').fadeOut(120);
         });
     }
+
+    // Fermeture via la touche Escape
+    $(document).on('keydown', function(e){
+        if (e.key === 'Escape' || e.keyCode === 27) {
+            if ($('#wdp-popup-main').is(':visible')) {
+                $('#wdp-popup-main').fadeOut(120);
+                setOnce('wdp_main_popup');
+            }
+            if ($('#wdp-popup-exit').is(':visible')) {
+                $('#wdp-popup-exit').fadeOut(120);
+            }
+        }
+    });
 })(jQuery);

--- a/includes/class-wdp-frontend.php
+++ b/includes/class-wdp-frontend.php
@@ -33,14 +33,14 @@ class WDP_Frontend {
         ?>
         <!-- Popup principal -->
         <?php if ( !empty($settings['main_enable']) && is_front_page() ) : ?>
-        <div id="wdp-popup-main" class="wdp-popup" style="display:none;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;">
+        <div id="wdp-popup-main" class="wdp-popup" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;">
             <button class="wdp-close" aria-label="Fermer">&times;</button>
             <div class="wdp-content"><?php echo wp_kses_post($settings['main_text']); ?></div>
         </div>
         <?php endif; ?>
         <!-- Popup sortie -->
         <?php if ( !empty($settings['exit_enable']) ) : ?>
-        <div id="wdp-popup-exit" class="wdp-popup" style="display:none;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;">
+        <div id="wdp-popup-exit" class="wdp-popup" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;">
             <button class="wdp-close" aria-label="Fermer">&times;</button>
             <div class="wdp-content"><?php echo wp_kses_post($settings['exit_text']); ?></div>
         </div>


### PR DESCRIPTION
## Summary
- close popups when pressing Escape
- mark popup containers as dialogs for screen readers

## Testing
- `npm test` *(fails: cannot find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685a8356f294832bb836a7b8e695772d