### PR TITLE
Add uninstall script for settings cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,8 @@
+<?php
+// Prevent direct file access
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Remove plugin settings
+delete_option( 'wdp_settings' );


### PR DESCRIPTION
## Summary
- add uninstall.php for WordPress plugin cleanup

## Testing
- `php -l uninstall.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a8335b310832bbcff137a14c136f4