### PR TITLE
Add popup width setting and glass style

### DIFF
--- a/assets/popups.css
+++ b/assets/popups.css
@@ -1,22 +1,13 @@
 .wdp-popup {
     position: fixed;
-left: 50%;
-top: 50%;
-transform: translate(-50%, -50%);
-z-index: 9999;
-max-width: 391px;         /* 340px + 15% = 391px */
-min-width: 253px;         /* 220px + 15% = 253px */
-box-shadow: 0 6px 32px rgba(0, 0, 0, 0.22), 0 4px 30px rgba(0, 0, 0, 0.15);
-border-radius: 16px;      /* Légère augmentation pour plus de douceur */
-padding: 32px 24px 23px 24px; /* 28px + 15% ≈ 32px (haut), 20px + 15% ≈ 23px (bas), largeur inchangée */
-text-align: center;
-transition: opacity 0.25s;
-opacity: 0.98;
-background: rgba(255, 255, 255, 0.18); /* Légèrement plus opaque */
-backdrop-filter: blur(6px);             /* Flou plus marqué */
--webkit-backdrop-filter: blur(8px);
-border: 1px solid rgba(255, 255, 255, 0.35);
-
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9999;
+    padding: 32px 24px 23px 24px;
+    text-align: center;
+    transition: opacity 0.25s;
+    opacity: 0.98;
 }
 .wdp-close {
     position: absolute;
@@ -39,4 +30,13 @@ border: 1px solid rgba(255, 255, 255, 0.35);
         padding: 18px 8vw 10px 8vw;
         font-size: 16px !important;
     }
+}
+.glass {
+  /* From https://css.glass */
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 7px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }

--- a/includes/class-wdp-admin.php
+++ b/includes/class-wdp-admin.php
@@ -34,6 +34,7 @@ class WDP_Admin {
         $output['main_text']   = wp_kses_post( $input['main_text'] );
         $output['main_font']   = sanitize_text_field( $input['main_font'] );
         $output['main_size']   = intval( $input['main_size'] );
+        $output['main_width']  = intval( $input['main_width'] );
         $output['main_color']  = sanitize_hex_color( $input['main_color'] );
         $output['main_bg']     = sanitize_hex_color( $input['main_bg'] );
 
@@ -42,6 +43,7 @@ class WDP_Admin {
         $output['exit_text']   = wp_kses_post( $input['exit_text'] );
         $output['exit_font']   = sanitize_text_field( $input['exit_font'] );
         $output['exit_size']   = intval( $input['exit_size'] );
+        $output['exit_width']  = intval( $input['exit_width'] );
         $output['exit_color']  = sanitize_hex_color( $input['exit_color'] );
         $output['exit_bg']     = sanitize_hex_color( $input['exit_bg'] );
 
@@ -59,12 +61,14 @@ class WDP_Admin {
             'main_text'   => '🎉 Découvrez notre événement annuel le 12 juillet à Bordeaux !',
             'main_font'   => 'Roboto',
             'main_size'   => 18,
+            'main_width'  => 340,
             'main_color'  => '#222222',
             'main_bg'     => '#ffffff',
             'exit_enable' => 1,
             'exit_text'   => 'Vous nous quittez déjà ? Abonnez-vous à notre newsletter pour ne rien manquer !',
             'exit_font'   => 'Roboto',
             'exit_size'   => 18,
+            'exit_width'  => 340,
             'exit_color'  => '#222222',
             'exit_bg'     => '#ffffff',
         ));
@@ -96,6 +100,10 @@ class WDP_Admin {
                     <div>
                         <label>Taille :</label>
                         <input type="number" name="wdp_settings[main_size]" value="<?php echo esc_attr($settings['main_size']); ?>" min="10" max="40"> px
+                    </div>
+                    <div>
+                        <label>Largeur :</label>
+                        <input type="number" name="wdp_settings[main_width]" value="<?php echo esc_attr($settings['main_width']); ?>" min="200" max="600"> px
                     </div>
                     <div>
                         <label>Couleur texte :</label>
@@ -133,6 +141,10 @@ class WDP_Admin {
                         <input type="number" name="wdp_settings[exit_size]" value="<?php echo esc_attr($settings['exit_size']); ?>" min="10" max="40"> px
                     </div>
                     <div>
+                        <label>Largeur :</label>
+                        <input type="number" name="wdp_settings[exit_width]" value="<?php echo esc_attr($settings['exit_width']); ?>" min="200" max="600"> px
+                    </div>
+                    <div>
                         <label>Couleur texte :</label>
                         <input type="color" name="wdp_settings[exit_color]" value="<?php echo esc_attr($settings['exit_color']); ?>">
                     </div>
@@ -148,13 +160,13 @@ class WDP_Admin {
             <div style="display:flex;gap:40px;">
                 <div>
                     <strong>Popup principal</strong>
-                    <div style="margin-top:10px;padding:20px;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;max-width:320px;border-radius:12px;">
+                    <div style="margin-top:10px;padding:20px;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;max-width:<?php echo esc_attr($settings['main_width']); ?>px;border-radius:12px;">
                         <?php echo wp_kses_post($settings['main_text']); ?>
                     </div>
                 </div>
                 <div>
                     <strong>Popup sortie</strong>
-                    <div style="margin-top:10px;padding:20px;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;max-width:320px;border-radius:12px;">
+                    <div style="margin-top:10px;padding:20px;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;max-width:<?php echo esc_attr($settings['exit_width']); ?>px;border-radius:12px;">
                         <?php echo wp_kses_post($settings['exit_text']); ?>
                     </div>
                 </div>

--- a/includes/class-wdp-frontend.php
+++ b/includes/class-wdp-frontend.php
@@ -33,14 +33,14 @@ class WDP_Frontend {
         ?>
         <!-- Popup principal -->
         <?php if ( !empty($settings['main_enable']) && is_front_page() ) : ?>
-        <div id="wdp-popup-main" class="wdp-popup" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;">
+        <div id="wdp-popup-main" class="wdp-popup glass" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['main_bg']); ?>;color:<?php echo esc_attr($settings['main_color']); ?>;font-family:<?php echo esc_attr($settings['main_font']); ?>;font-size:<?php echo esc_attr($settings['main_size']); ?>px;max-width:<?php echo esc_attr($settings['main_width']); ?>px;">
             <button class="wdp-close" aria-label="Fermer">&times;</button>
             <div class="wdp-content"><?php echo wp_kses_post($settings['main_text']); ?></div>
         </div>
         <?php endif; ?>
         <!-- Popup sortie -->
         <?php if ( !empty($settings['exit_enable']) ) : ?>
-        <div id="wdp-popup-exit" class="wdp-popup" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;">
+        <div id="wdp-popup-exit" class="wdp-popup glass" role="dialog" aria-modal="true" style="display:none;background:<?php echo esc_attr($settings['exit_bg']); ?>;color:<?php echo esc_attr($settings['exit_color']); ?>;font-family:<?php echo esc_attr($settings['exit_font']); ?>;font-size:<?php echo esc_attr($settings['exit_size']); ?>px;max-width:<?php echo esc_attr($settings['exit_width']); ?>px;">
             <button class="wdp-close" aria-label="Fermer">&times;</button>
             <div class="wdp-content"><?php echo wp_kses_post($settings['exit_text']); ?></div>
         </div>

--- a/wp-double-popups.php
+++ b/wp-double-popups.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WP Double Popups
 Description: Affiche deux popups personnalisables (principal & sortie) avec gestion avancée depuis l’admin.
-Version: 1.0.0
+Version: 1.1.0
 Author: Développeur Expert WordPress
 License: GPL2
 
@@ -15,7 +15,7 @@ INSTALLATION :
 // Sécurité : Bloquer l’accès direct
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'WDP_VERSION', '1.0.0' );
+define( 'WDP_VERSION', '1.1.0' );
 define( 'WDP_PATH', plugin_dir_path(__FILE__) );
 define( 'WDP_URL', plugin_dir_url(__FILE__) );
 
@@ -30,12 +30,14 @@ function wdp_activate() {
             'main_text'   => '🎉 Découvrez notre événement annuel le 12 juillet à Bordeaux !',
             'main_font'   => 'Roboto',
             'main_size'   => 18,
+            'main_width'  => 340,
             'main_color'  => '#222222',
             'main_bg'     => '#ffffff',
             'exit_enable' => 1,
             'exit_text'   => 'Vous nous quittez déjà ? Abonnez-vous à notre newsletter pour ne rien manquer !',
             'exit_font'   => 'Roboto',
             'exit_size'   => 18,
+            'exit_width'  => 340,
             'exit_color'  => '#222222',
             'exit_bg'     => '#ffffff',
         );


### PR DESCRIPTION
## Summary
- allow popup width customization
- apply "glass" styling for popup backgrounds
- bump version to 1.1.0

## Testing
- `php -l wp-double-popups.php` *(fails: command not found)*
- `php -l includes/class-wdp-admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8a4f5c78832b8b2b5b118cc8554c